### PR TITLE
Bump ClojureCLR version to 1.12.0-alpha9, which supports .NET 8

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ClojureCLR
-RUN dotnet tool install --global --version 1.12.0-alpha7 Clojure.Main
+RUN dotnet tool install --global --version 1.12.0-alpha9 Clojure.Main
 
 # Babashka gives us tools.deps power
 RUN curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install \


### PR DESCRIPTION
Jacking-in from Calva failed with the messages below. Updating the ClojreCLR fixed it. I think this ClojureCLR version will work with .NET 6,  7 and 8.

⚡️ Starting the REPL ⚡️ using the below command line:
(cd /Users/henrik/src/clojure/clr/clojure-clr-starter; docker compose exec -it dotnet-clojure /app/docker/start-repl.sh )
Exported CLOJURE_LOAD_PATH: src:dev:/app/dependencies/tools.nrepl-0.1.0-alpha1:/app/dependencies/tools.reader-1.3.7
You must install or update .NET to run this application.

App: /root/.dotnet/tools/Clojure.Main
Architecture: arm64
Framework: 'Microsoft.NETCore.App', version '7.0.0' (arm64)
.NET location: /usr/share/dotnet

The following frameworks were found:
  8.0.6 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]

Learn more:
https://aka.ms/dotnet/app-launch-failed

To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=7.0.0&arch=arm64&rid=linux-arm64&os=debian.12
Jack-in process exited. Status: 150
